### PR TITLE
[Niyas][WD-121951] Drift, Other Fixes

### DIFF
--- a/frontend/src/api/apis.ts
+++ b/frontend/src/api/apis.ts
@@ -8,6 +8,7 @@ export const GET_MODELS_API = makeUrl('list.models');
 export const GET_MODEL_Info_API = makeUrl('model.info');
 export const GET_MODEL_Overview_API = makeUrl('model.overview');
 export const GET_MODEL_PERFORMANCE_API = makeUrl('metric.performance');
+export const GET_METRICS_PSI = makeUrl('metric.psi')
 export const CREATE_MODEL_API = makeUrl('model.register');
 export const GET_MODEL_VERSION_INFO_API = makeUrl('model.version.info')
 export const UPDATE_MODEL_API = makeUrl('model.update');

--- a/frontend/src/api/models/GetMetricsPsi.ts
+++ b/frontend/src/api/models/GetMetricsPsi.ts
@@ -1,0 +1,39 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import axios from '../../utils/axios';
+import { GET_METRICS_PSI } from '../apis';
+
+interface GetMetricsPsiResponse {
+    description?: any;
+    drift_psi: Array<any>
+}
+
+interface GetMetricsPsiParams {
+  model_id: string,
+  model_version_id: string,
+  start_time: Date | null,
+  end_time: Date | null
+}
+
+type MetricsPsiQuery = UseQueryResult<any, unknown>;
+
+interface UseMetricsPsi {
+  (params: GetMetricsPsiParams): MetricsPsiQuery;
+}
+
+export const useMetricsPsi: UseMetricsPsi  = (params) => {
+
+  return useQuery(['metric.psi', params], queryModels, {
+    refetchOnWindowFocus: false
+  });
+
+  async function queryModels() {
+    try {
+        const response = await axios.get<GetMetricsPsiResponse>(
+            GET_METRICS_PSI, { params }
+          );
+        return response.data;
+    } catch (error) {
+        throw error;
+    }
+  }
+};

--- a/frontend/src/components/Tables/collapsible-table-1/CollapsibleTableRow.tsx
+++ b/frontend/src/components/Tables/collapsible-table-1/CollapsibleTableRow.tsx
@@ -49,92 +49,19 @@ export default function CollapsibleTableRow(props: { row: any }) {
   const classes = useStyles();
   const { row } = props;
 
-  const [open, setOpen] = useState(false);
-
   return (
     <>
       <TableRow
-        // onClick={() => {
-        //   setOpen(!open);
-        // }}
         sx={{ border: `1px solid ${colors.tableHeadBack}`, borderBottom: 0 }}
-        className={`${open ? classes.openBack : ''} borderBottom`}
+        className= "borderBottom"
       >
         <TableCell className={classes.name}>
-          <IconButton size="small" onClick={() => setOpen(!open)}>
-            <Icon icon={open ? arrowIosUpwardFill : arrowIosDownwardFill} />
-          </IconButton>
           &nbsp;
           {row.name}
         </TableCell>
 
-        <TableCell style={{ display: 'flex', justifyContent: 'center' }}>
-          <ChartBar
-            name={row.name}
-            categories={row.buckets}
-            data={row.hist_values}
-            options={{
-              height: 60,
-              width: '200',
-              sparkline: true,
-              enableDataLabels: false,
-              showGridLines: false,
-              showYAxisLabels: false,
-              color: colors.graphDark,
-              followCursor: true,
-              tooltip: {
-                enabled: true,
-                followCursor: true,
-                style: {
-                  fontSize: '12px',
-                  fontFamily: 'Poppins'
-                },
-                onDatasetHover: {
-                  highlightDataSeries: false
-                },
-                x: {
-                  show: false
-                },
-                y: {
-                  formatter: undefined,
-                  title: {
-                    formatter: () => ''
-                  }
-                },
-                marker: {
-                  show: false
-                }
-              }
-            }}
-          />
-        </TableCell>
         <TableCell align="center" width="20%">
-          {Math.round(row.impact * 1000) / 1000}
-        </TableCell>
-      </TableRow>
-
-      <TableRow sx={{ border: '1px solid #E5E8EB', borderTop: 0 }} className={classes.openBack}>
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
-          <Collapse in={open} timeout="auto" unmountOnExit>
-            <>
-              <Box className={classes.minMax}>
-                Dataset {row.name}: Accuracy minimum is {Math.min(...row.hist_values)} and maximum
-                is {Math.max(...row.hist_values)}
-              </Box>
-              <ChartBar
-                name={row.name}
-                categories={row.buckets}
-                data={row.hist_values}
-                options={{
-                  height: 200,
-                  width: '80%',
-                  color: colors.graphLight,
-                  enableDataLabels: false,
-                  columnWidth: '50%'
-                }}
-              />
-            </>
-          </Collapse>
+          {Math.round(row.driftscore * 1000) / 1000}
         </TableCell>
       </TableRow>
     </>

--- a/frontend/src/components/Tables/collapsible-table-1/index.tsx
+++ b/frontend/src/components/Tables/collapsible-table-1/index.tsx
@@ -41,11 +41,8 @@ export default function CollapsibleTable({ tablehead_name, dataValue }: Props) {
               <TableCell className={classes.tableHead} width="20">
                 &nbsp;&nbsp;&nbsp;&nbsp;{tablehead_name}
               </TableCell>
-              <TableCell className={classes.tableHead} align="center" width="60">
-                Histogram
-              </TableCell>
               <TableCell className={classes.tableHead} align="center" width="20">
-                Impact
+                Drift Score
               </TableCell>
             </TableRow>
           </TableHead>

--- a/frontend/src/pages/Models/ModelDetails/ModelDataProfile/DataProfileCards.tsx
+++ b/frontend/src/pages/Models/ModelDetails/ModelDataProfile/DataProfileCards.tsx
@@ -122,6 +122,7 @@ export const DataDatasetSelectCard = (props: any) => {
   const handleChangeVersion = (event: any) => {
     setSelected(event.target.value);
     setSelectedName(data?.data.dataset_list.find(dataset => dataset.dataset_id === event.target.value)?.dataset_name || '');
+    props.on_change(event.target.value);
   }
   const { data } = useGetDatasets({ version_id: props.version_id });
 

--- a/frontend/src/pages/Models/ModelDetails/ModelDrift/ModelDrift.tsx
+++ b/frontend/src/pages/Models/ModelDetails/ModelDrift/ModelDrift.tsx
@@ -1,82 +1,148 @@
-import Page from '../../../../components/Page';
-import LoadingScreen from '../../../../components/LoadingScreen';
-import CollapsibleTable from '../../../../components/Tables/collapsible-table-1';
-import { MenuItem, Grid, Box, TextField } from '@material-ui/core';
-import { experimentalStyled as styled } from '@material-ui/core/styles';
-import { Heading } from '../../../../components/Heading';
-import { makeStyles } from '@material-ui/core/styles';
-import { colors } from '../../../../theme/colors';
+import Page from "../../../../components/Page";
+import LoadingScreen from "../../../../components/LoadingScreen";
+import CollapsibleTable from "../../../../components/Tables/collapsible-table-1";
+import { MenuItem, Grid, Box, TextField } from "@material-ui/core";
+import { experimentalStyled as styled } from "@material-ui/core/styles";
+import { DateRangeFilterState } from "../../../../redux/slices/dateRangeFilter";
+import { Heading } from "../../../../components/Heading";
+import { makeStyles } from "@material-ui/core/styles";
+import { colors } from "../../../../theme/colors";
 
-import ChartBar from '../../../../components/charts/ChartBar';
-const data = {
+import ChartBar from "../../../../components/charts/ChartBar";
+import { useSelector } from "react-redux";
+import { useLocation, useParams } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import VersionSelect from "../VersionSelect";
+import { useMetricsPsi } from "api/models/GetMetricsPsi";
+import Scrollbar from "components/Scrollbar";
+
+function useQuery() {
+  const { search } = useLocation();
+
+  return useMemo(() => new URLSearchParams(search), [search]);
+}
+
+const daeta = {
   feat_breakdown: [
     {
-      buckets: ['f_0', 'f_1', 'f_2', 'f_3', 'f_4', 'f_5', 'f_6', 'f_7', 'f_8', 'f_9'],
-      hist_values: [22, 27, 23, 30, 13, 27, 20, 15, 12, 10],
-      impact: 0.1725,
-      name: 'Fico_Score'
+      driftscore: 0.1725,
+      name: "Fico_Score",
     },
     {
-      buckets: ['f_0', 'f_1', 'f_2', 'f_3', 'f_4', 'f_5', 'f_6', 'f_7', 'f_8', 'f_9'],
-      hist_values: [22, 27, 23, 30, 13, 27, 20, 15, 12, 10],
-      impact: 0.1725,
-      name: 'Fico_Score'
+      driftscore: 0.1725,
+      name: "Fico_Score",
     },
     {
-      buckets: ['f_0', 'f_1', 'f_2', 'f_3', 'f_4', 'f_5', 'f_6', 'f_7', 'f_8', 'f_9'],
-      hist_values: [22, 27, 23, 30, 13, 27, 20, 15, 12, 10],
-      impact: 0.1725,
-      name: 'Fico_Score'
-    }
+      driftscore: 0.1725,
+      name: "Fico_Score",
+    },
   ],
   data: [84, 77, 53, 76, 54, 71, 73, 71, 68, 70],
   time_buckets: [
-    '2022-05-19T10:41:58.617981',
-    '2022-05-18T10:41:58.617988',
-    '2022-05-17T10:41:58.617989',
-    '2022-05-16T10:41:58.617990',
-    '2022-05-15T10:41:58.617991',
-    '2022-05-14T10:41:58.617992',
-    '2022-05-13T10:41:58.617993',
-    '2022-05-12T10:41:58.617994',
-    '2022-05-11T10:41:58.617995',
-    '2022-05-10T10:41:58.617996'
-  ]
+    "2022-05-19T10:41:58.617981",
+    "2022-05-18T10:41:58.617988",
+    "2022-05-17T10:41:58.617989",
+    "2022-05-16T10:41:58.617990",
+    "2022-05-15T10:41:58.617991",
+    "2022-05-14T10:41:58.617992",
+    "2022-05-13T10:41:58.617993",
+    "2022-05-12T10:41:58.617994",
+    "2022-05-11T10:41:58.617995",
+    "2022-05-10T10:41:58.617996",
+  ],
 };
-const RootStyle = styled('div')({
-  overflowY: 'hidden',
-  padding: '1.6rem 2.4rem',
-  background: colors.white
+const RootStyle = styled("div")({
+  overflowY: "hidden",
+  padding: "1.6rem 2.4rem",
+  background: colors.white,
 });
 const useStyles = makeStyles(() => ({
   graph: {
-    maxWidth: '1000px'
+    maxWidth: "100%",
   },
   table: {
-    marginTop: '1.6rem',
-    maxWidth: '1000px'
-  }
+    marginTop: "1.6rem",
+    maxWidth: "80%",
+  },
 }));
 
 const ModelDrift = () => {
   const classes = useStyles();
+  let query = useQuery();
+  const { modelId } = useParams();
+  const versionId = query.get("version_id");
+  const [given_versionId, setGivenVersionId] = useState(versionId ?? "");
+  const handleVersionChange = (version: string) => {
+    setGivenVersionId(version);
+  };
+
+  const { fromDate, toDate } = useSelector(
+    (state: { dateRangeFilter: DateRangeFilterState }) => state.dateRangeFilter
+  );
+  
+  const { data, isLoading, error } = useMetricsPsi({
+    model_id: modelId,
+    model_version_id: given_versionId,
+    start_time: fromDate,
+    end_time: toDate
+  })
+  
 
   return (
     <Page title="Model Drift | Waterdip">
       <RootStyle>
-        <Box className={classes.graph}>
-          <Heading heading="Prediction drift over time" subtitle="Prediction drift over time" />
-          <ChartBar
-            data={data.data}
-            categories={data.time_buckets.map((bucket: string) => bucket.split('T')[0])}
-            name={'PSI'}
-            options={{ width: '100%', height: 240, columnWidth: '50%', enableDataLabels: false }}
-          />
+        {data && Object.keys(data).length > 0 ?
+          <>
+            <Box display="grid" maxWidth="80%" gridAutoColumns="auto">
+          <Box className={classes.graph} gridColumn="1/3" gridRow="2/4">
+            <Heading
+              heading="Prediction drift over time"
+              subtitle="Prediction drift over time"
+            />
+            <ChartBar
+              data={data.data ? data.data : []}
+              categories={data.time_buckets ? data.time_buckets.map(
+                (bucket: string) => bucket.split("T")[0]
+              ): []}
+              name={"PSI"}
+              options={{
+                width: "100%",
+                height: 240,
+                columnWidth: "50%",
+                enableDataLabels: false,
+              }}
+            />
+          </Box>
+          <Box gridColumn="3/4" gridRow="2/4" sx={{ mb: 5 }}>
+            <VersionSelect
+              on_change={handleVersionChange}
+              subtitle="Select a version to view drift"
+            />
+          </Box>
         </Box>
         <Box className={classes.table}>
           <Heading heading="Feature Breakdown" subtitle="Feature breakdown" />
-          <CollapsibleTable tablehead_name="Feature Class" dataValue={data.feat_breakdown} />
+          <CollapsibleTable
+            tablehead_name="Feature Class"
+            dataValue={data.feat_breakdown ? data.feat_breakdown : []}
+          />
         </Box>
+          </>
+          : (
+            <>
+              <Box gridColumn="2/3" gridRow="2/4">
+                <Scrollbar>
+                  <Box sx={{ py: 3, px: 1 }}>
+                    <Box sx={{ height: "calc(100vh - 150px)" }}>
+                      <LoadingScreen />
+                    </Box>
+                  </Box>
+                </Scrollbar>
+              </Box>
+            </>
+          )
+        }
+        
       </RootStyle>
     </Page>
   );

--- a/frontend/src/pages/Models/ModelDetails/ModelPerformance/ModelPerformance.tsx
+++ b/frontend/src/pages/Models/ModelDetails/ModelPerformance/ModelPerformance.tsx
@@ -22,7 +22,7 @@ import PerformanceChart from "./PerformanceChart";
 import { AxiosError, AxiosRequestConfig } from "axios";
 import Button from "@material-ui/core/Button";
 import { PATH_DASHBOARD } from "routes/paths";
-import VersionSelect from "./VersionSelect";
+import VersionSelect from "../VersionSelect";
 
 const RootStyle = styled("div")({
   overflowY: "hidden",
@@ -130,7 +130,7 @@ const ModelPerformance = () => {
                 </Scrollbar>
               </Box>
               <Box gridColumn="3/4" gridRow="2/2" sx={{ ml: 2, mb: 5 }}>
-                <VersionSelect on_change={handleVersionChange} />
+                <VersionSelect on_change={handleVersionChange} subtitle="Select a version to view performance"/>
               </Box>
             </>
           ) : (

--- a/frontend/src/pages/Models/ModelDetails/VersionSelect.tsx
+++ b/frontend/src/pages/Models/ModelDetails/VersionSelect.tsx
@@ -1,8 +1,8 @@
-import { Heading } from "../../../../components/Heading";
+import { Heading } from "../../../components/Heading";
 import { makeStyles } from "@material-ui/styles";
 import { MenuItem } from "@material-ui/core";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { colors } from "../../../../theme/colors";
+import { colors } from "../../../theme/colors";
 import { useEffect, useMemo, useState } from "react";
 import { Select } from "@material-ui/core";
 import { useModelInfo } from "api/models/GetModelInfo";
@@ -30,11 +30,11 @@ const useStyles = makeStyles({
   },
   baseLine: {
     paddingLeft: ".8rem",
-    marginTop: "-2rem",
   },
   baseLineContent: {
     marginTop: ".6rem",
     width: "100%",
+    maxWidth: "250px",
     color: colors.text,
     background: colors.boxBackground,
     borderRadius: "4px",
@@ -60,7 +60,7 @@ function useQuery() {
   return useMemo(() => new URLSearchParams(search), [search]);
 }
 
-export default function VersionSelect({ on_change }: any) {
+export default function VersionSelect({ on_change, subtitle }: any) {
   const navigate = useNavigate();
   const { modelId, tabName } = useParams();
   const classes = useStyles();
@@ -80,7 +80,7 @@ export default function VersionSelect({ on_change }: any) {
     <div className={classes.baseLine}>
       <Heading
         heading="Model Version"
-        subtitle="Select a version to view performance"
+        subtitle={subtitle}
       />
       <div className={classes.baseLineContent}>
         <div className={classes.contentHeading}>Select Version</div>
@@ -97,7 +97,7 @@ export default function VersionSelect({ on_change }: any) {
           {modelOverview &&
             modelOverview?.data?.data?.model_versions?.map((row: any) => (
               <MenuItem value={row.model_version_id} key={row}>
-                {row.model_version_id}
+                {row.model_version}
               </MenuItem>
             ))}
         </Select>


### PR DESCRIPTION
# Changes

- `VersionSelect.tsx` had a purpose and had to be used in multiple pages of Model Details as a component, so we've changed the directory for it.
- Implemented version selection in the drift page. It is ready to be integrated with the API.
- Update the `Drift Table` to only have the `feature_name` and `drift_score`.

# Fixes

- Fixed a bug wherein, the datasets weren't being fetched and displayed.
- Edited the `Performance Page` to show version `name` instead of `version_Id`
- Formatted the `Drift Page` appropriately, for a better view.

# Screenshots

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/84234554/221922201-710a7688-2115-4a62-9a3b-a71847e95ba8.png">

