### PR TITLE
[Niyas][WD-142018] Dataset Refetch on Dates

### DIFF
--- a/frontend/src/api/datasets/GetMetricsDataset.ts
+++ b/frontend/src/api/datasets/GetMetricsDataset.ts
@@ -69,13 +69,13 @@ interface GetMetricsDatasetParams {
   model_id: string;
   model_version_id: string;
   dataset_id: string;
-  start_date?: Date | null;
-  end_date?: Date | null;
+  start_time?: Date | null;
+  end_time?: Date | null;
 }
 
 
-export const useGetMetricsDataset = ({model_id, model_version_id, dataset_id, start_date, end_date }: GetMetricsDatasetParams) => {
-  return useQuery([dataset_id], queryDataset, {
+export const useGetMetricsDataset = ({model_id, model_version_id, dataset_id, start_time, end_time }: GetMetricsDatasetParams) => {
+  return useQuery([dataset_id, start_time, end_time], queryDataset, {
     refetchOnWindowFocus: false
   });
   async function queryDataset() {
@@ -83,8 +83,8 @@ export const useGetMetricsDataset = ({model_id, model_version_id, dataset_id, st
       model_id: model_id,
       model_version_id: model_version_id, 
       dataset_id: dataset_id,
-      start_date: start_date,
-      end_date: end_date
+      start_time: start_time,
+      end_time: end_time
     };
     const response = await axios.get<DatasetInfoResponse>(GET_METRICS_DATASET, {
       params: apiParams

--- a/frontend/src/components/Tables/collapsible-table-2/CollapsibleTableRow.tsx
+++ b/frontend/src/components/Tables/collapsible-table-2/CollapsibleTableRow.tsx
@@ -177,13 +177,13 @@ export default function CollapsibleTableRow(props: { row: any, data_type: any })
           <Collapse in={open} timeout="auto" unmountOnExit>
             <>
               <Box className={classes.minMax}>
-                Dataset {row.column_name}: Accuracy minimum is {Math.min(...row.histogram.val)} and
-                maximum is {Math.max(...row.histogram.val)}
+                Dataset {row.column_name}: Accuracy minimum is { row.histogram && row.histogram.val ? Math.min(...row.histogram.val) : "Infinity"} and
+                maximum is { row.histogram && row.histogram.val ? Math.max(...row.histogram.val) : "Infinity"}
               </Box>
               <ChartBar
                 name={row.column_name}
-                categories={row.histogram.bins}
-                data={row.histogram.val}
+                categories={row.histogram && row.histogram.bins ? row.histogram.bins: []}
+                data={row.histogram && row.histogram.val ? row.histogram.val : []}
                 options={{
                   height: 200,
                   width: '70%',

--- a/frontend/src/pages/Models/ModelDetails/ModelDataProfile/DataProfileStatics.tsx
+++ b/frontend/src/pages/Models/ModelDetails/ModelDataProfile/DataProfileStatics.tsx
@@ -18,8 +18,8 @@ export const DataProfileStats = ({ datasetId, model_id, model_version_id }: any)
       model_id: model_id,
       model_version_id: model_version_id,
       dataset_id: datasetId,
-      start_date: fromDate,
-      end_date: toDate 
+      start_time: fromDate,
+      end_time: toDate 
   })
   const datasetInfo = data && data.data;
   return (


### PR DESCRIPTION
# Bug

There was an issue with the Dataset portion, when the user fetches via the `PRODUCTION` Dataset mode, the fetch wasn't occurring again. This was linked with another issue wherein the page crashes because of non-existent data of the `Histogram`.

# Follow Up

The mistake, along with another error was patched in this PR. But it is observed that some of the values are long decimals, and must be rounded off from the backend.

# Screenshots

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/84234554/226623108-228f3b24-cad9-48ea-93b5-c45b967d7b1c.png">
